### PR TITLE
Update asset headers and remove compression plugin

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -2,32 +2,24 @@
   "cleanUrls": true,
   "headers": [
     {
-      "source": "/assets/(.*).br",
+      "source": "/assets/:path*.js",
       "headers": [
-        { "key": "Content-Encoding", "value": "br" },
-        { "key": "Content-Type", "value": "application/javascript" },
+        { "key": "Content-Type", "value": "application/javascript; charset=utf-8" },
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     },
     {
-      "source": "/assets/(.*).gz",
+      "source": "/assets/:path*.css",
       "headers": [
-        { "key": "Content-Encoding", "value": "gzip" },
-        { "key": "Content-Type", "value": "application/javascript" },
+        { "key": "Content-Type", "value": "text/css; charset=utf-8" },
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     },
     {
-      "source": "/assets/(.*).js",
-      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
-    },
-    {
-      "source": "/assets/(.*).css",
-      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
-    },
-    {
-      "source": "/assets/images/(.*)",
-      "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400, s-maxage=31536000" }]
+      "source": "/assets/images/:path*",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=86400, s-maxage=31536000" }
+      ]
     }
   ],
   "framework": "vite",

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-import viteCompression from "vite-plugin-compression";
 import { visualizer } from "rollup-plugin-visualizer";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -12,16 +11,7 @@ export default defineConfig({
       jsxRuntime: "automatic",
     }),
     tailwindcss(),
-    viteCompression({
-      algorithm: "brotliCompress",
-      threshold: 1024, // Only compress files larger than 1KB
-      compressionOptions: { level: 11 }, // Maximum compression
-    }),
-    viteCompression({
-      algorithm: "gzip",
-      threshold: 1024,
-      compressionOptions: { level: 9 },
-    }),
+    // Note: Vercel handles brotli/gzip compression automatically at the edge.
     visualizer({
       filename: "dist/stats.html",
       open: false,


### PR DESCRIPTION
Simplified and updated asset header rules in vercel.json to set appropriate Content-Type and caching for JS, CSS, and images. Removed vite-plugin-compression from vite.config.ts as Vercel now handles Brotli and gzip compression automatically at the edge.